### PR TITLE
Day12 without base3, parallel tasks, output to files

### DIFF
--- a/Day12/ConditionRecordsAnalyzer.cs
+++ b/Day12/ConditionRecordsAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -16,18 +17,33 @@ public class ConditionRecordsAnalyzer
             .ToArray();
     }
 
-    public int GetSumOfPossibleArrangements()
+    public int GetSumOfPossibleArrangements(int startIndex, int rows)
     {
         List<int> counts = new();
 
-        foreach (var record in records)
+        Stopwatch stopwatch = new();
+        for (int i = startIndex; i < records.Length; i++)
         {
-            counts.Add(CountPossibleArrangements(record));
-        }
+            ConditionRecord? record = records[i];
+            stopwatch.Restart();
+            int count = CountPossibleArrangements(record);
+            stopwatch.Stop();
+            Console.WriteLine($"{i}.\t{stopwatch.Elapsed}\t{count}");
+            counts.Add(count);
 
+            if (counts.Count >= rows)
+                break;
+        }
         return counts.Sum();
     }
-
+    public int GetSumOfPossibleArrangements(int startIndex)
+    {
+        return GetSumOfPossibleArrangements(startIndex, records.Length - startIndex);
+    }
+    public int GetSumOfPossibleArrangements()
+    {
+        return GetSumOfPossibleArrangements(0);
+    }
     private int CountPossibleArrangements(ConditionRecord record)
     {
         return IterateOnRemainingParts([record.Row], record.DamagedGroups);

--- a/Day12/CountingProgressReport.cs
+++ b/Day12/CountingProgressReport.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics;
+using static Day12.ConditionRecordsAnalyzer;
+
+namespace Day12;
+public class CountingProgressReport
+{
+    public Stopwatch Stopwatch { get; set; }
+    public ConditionRecord? Record { get; set; }
+    public int Count { get; set; } = 0;
+    public int TaskNumber { get; set; }
+
+    public CountingProgressReport(ConditionRecord? record, int taskNumber)
+    {
+        Record = record;
+        Stopwatch = Stopwatch.StartNew();
+        TaskNumber = taskNumber;
+    }
+}

--- a/Day12/Program.cs
+++ b/Day12/Program.cs
@@ -1,13 +1,47 @@
 ﻿using Day12;
 
+int? startIndex = null, rows = null;
+
+if (args.Length >= 1)
+{
+    startIndex = int.Parse(args[0]);
+}
+if (args.Length == 2)
+{
+    rows = int.Parse(args[1]);
+}
+
 ConditionRecordsAnalyzer analyzer = new("input.txt");
 
-int sum = analyzer.GetSumOfPossibleArrangements();
+int sum;
+if (startIndex is null)
+{
+    sum = analyzer.GetSumOfPossibleArrangements();
+}
+else if (rows is null)
+{
+    sum = analyzer.GetSumOfPossibleArrangements((int)startIndex);
+}
+else
+{
+    sum = analyzer.GetSumOfPossibleArrangements((int)startIndex, (int)rows);
+}
 
 Console.WriteLine($"Part 1: {sum}");
 
 analyzer = new("input.txt", 5);
 
-int sumWithCopies = analyzer.GetSumOfPossibleArrangements();
+if (startIndex is null)
+{
+    sum = analyzer.GetSumOfPossibleArrangements();
+}
+else if (rows is null)
+{
+    sum = analyzer.GetSumOfPossibleArrangements((int)startIndex);
+}
+else
+{
+    sum = analyzer.GetSumOfPossibleArrangements((int)startIndex, (int)rows);
+}
 
-Console.WriteLine($"Part 2: {sumWithCopies}");
+Console.WriteLine($"Part 2: {sum}");

--- a/Day12/Program.cs
+++ b/Day12/Program.cs
@@ -1,47 +1,17 @@
 ﻿using Day12;
 
-int? startIndex = null, rows = null;
+int taskCount = 1;
+int copies = 1;
 
 if (args.Length >= 1)
 {
-    startIndex = int.Parse(args[0]);
+    copies = int.Parse(args[0]);
 }
 if (args.Length == 2)
 {
-    rows = int.Parse(args[1]);
+    taskCount = int.Parse(args[1]);
 }
 
-ConditionRecordsAnalyzer analyzer = new("input.txt");
+ConditionRecordsAnalyzer analyzer = new("input.txt", "output", copies);
 
-int sum;
-if (startIndex is null)
-{
-    sum = analyzer.GetSumOfPossibleArrangements();
-}
-else if (rows is null)
-{
-    sum = analyzer.GetSumOfPossibleArrangements((int)startIndex);
-}
-else
-{
-    sum = analyzer.GetSumOfPossibleArrangements((int)startIndex, (int)rows);
-}
-
-Console.WriteLine($"Part 1: {sum}");
-
-analyzer = new("input.txt", 5);
-
-if (startIndex is null)
-{
-    sum = analyzer.GetSumOfPossibleArrangements();
-}
-else if (rows is null)
-{
-    sum = analyzer.GetSumOfPossibleArrangements((int)startIndex);
-}
-else
-{
-    sum = analyzer.GetSumOfPossibleArrangements((int)startIndex, (int)rows);
-}
-
-Console.WriteLine($"Part 2: {sum}");
+await analyzer.RunCountingTasks(taskCount);


### PR DESCRIPTION
Removed conversion to and from base3 ints to improve performance.
Then the app was modified to run parallel tasks and save output to files. Maybe this way, row by row, it will produce the correct result.